### PR TITLE
Update gnuplot version requirement

### DIFF
--- a/gnuplot-multiplot.gemspec
+++ b/gnuplot-multiplot.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   [
-    ["gnuplot", "~> 2.6.2"],
+    ["gnuplot", "~> 2.6"],
   ].each do |args|
     spec.add_dependency(*args)
   end


### PR DESCRIPTION
Changed version requirement for gnuplot to 2.6 — less specific but should still work.
